### PR TITLE
When not specified by the user at run time, collectd emits under it's…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Run collectd with the default configuration with the following command:
 
 ```
 docker run --privileged -e "SF_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXX" \
-  -v /proc:/mnt/proc:ro -v /etc:/mnt/etc:ro quay.io/signalfuse/collectd
+  -v /etc/hostname:/mnt/hostname:ro -v /proc:/mnt/proc:ro -v \
+  /etc:/mnt/etc:ro quay.io/signalfuse/collectd
 ```
 
 If you just want to look around inside the image, you can run `bash`.
@@ -25,7 +26,8 @@ and start collectd.
 
 ```
 docker run -ti --privileged -e "SF_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXX" \
-  -v /proc:/mnt/proc:ro -v /etc:/mnt/etc:ro quay.io/signalfuse/collectd bash
+  -v /etc/hostname:/mnt/hostname:ro -v /proc:/mnt/proc:ro \
+  -v /etc:/mnt/etc:ro quay.io/signalfuse/collectd bash
 ```
 
 If you don't want to pass your API token through a command-line argument, you
@@ -34,6 +36,7 @@ can put `SF_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXX` into a file (that you can
 
 ```
 docker run --privileged --env-file=token.env \
+  -v /etc/hostname:/mnt/hostname:ro \
   -v /proc:/mnt/proc:ro -v /etc:/mnt/etc:ro quay.io/signalfuse/collectd
 ```
 
@@ -42,7 +45,8 @@ On CoreOS because /etc/*-release are symlinks you want to mount
 
 ```
 docker run --privileged -e "SF_API_TOKEN=XXXXXXXXXXXXXXXXXXXXXX" \
-  -v /proc:/mnt/proc:ro -v /usr/share/coreos:/mnt/etc:ro quay.io/signalfuse/collectd
+  -v /etc/hostname:/mnt/hostname:ro -v /proc:/mnt/proc:ro \
+  -v /usr/share/coreos:/mnt/etc:ro quay.io/signalfuse/collectd
 ```
 
 ## FAQ
@@ -61,6 +65,17 @@ SignalFx Collectd Plugin will function correctly and report the right
 information.  If you leave it out you will see the container's OS in the
 meta-data for this host.
 
+### Do I need to provide a host name?
+
+You have an option to either bind mount your host's `/etc/hostname` to the 
+container's `/mnt/hostname` or to set the environment variable 
+`COLLECTD_HOSTNAME`. You may set the environment variable using the runtime 
+option `-e "COLLECTD_HOSTNAME=<hostname>"` where `<hostname>` is a 
+valid host name string. You may also set the environment variable in an optional
+ environment file.  Please note that if `/etc/hostname` is mounted and 
+ `COLLECTD_HOSTNAME` is set, that the mounted host name will be used.
+A hostname must be specified regardless of the method.
+
 ### Why can't I exec into the running docker container?
 
 Because the docker container's proc filesystem has been replaced by the host
@@ -70,12 +85,15 @@ above on how to run the image with a different command so you can then execute
 
 ### Can I configure anything?
 
-Yes! You are required to set the `SF_API_TOKEN`, but you also can set the
-following:
+Yes! You are required to set the `SF_API_TOKEN` and provide a hostname either 
+by mounting `/etc/hostname` to `/mnt/hostname` or setting `COLLECTD_HOSTNAME`,
+but you also can set the following:
 
 1. `COLLECTD_HOSTNAME` - if set we will set this in
-   `/etc/collectd/collectd.conf`, otherwise collectd will use DNS to figure
-   out your hostname.
+   `/etc/collectd/collectd.conf`.  If the environment variable is not set, 
+   we will attempt to cat `/mnt/hostname` for the host's hostname.  If no hostname
+   is discovered, we will exit with an error code of 1 and display a message
+   indicating that a hostname could not be found.
 1. `COLLECTD_INTERVAL` - if set we will use the specified interval for collectd
    and the plugin, otherwise the default interval is 10 seconds.
 1. `COLLECTD_CONFIGS` - if set we will include `$COLLECTD_CONFIGS/*.conf` in

--- a/run.sh
+++ b/run.sh
@@ -15,9 +15,25 @@ fi
 if [ -n "$COLLECTD_CONFIGS" ]; then
 	echo "Include \"$COLLECTD_CONFIGS/*.conf\"" >> $COLLECTD_CONF
 fi
-HOSTNAME="FQDNLookup true"
+#If the user sets COLLECTD_HOSTNAME then assign to HOSTNAME
 if [ -n "$COLLECTD_HOSTNAME" ]; then
 	HOSTNAME="Hostname \"$COLLECTD_HOSTNAME\""
+	echo "Emitting Metrics With Hostname: \"$HOST_HOSTNAME\""
+#If the host's hostname is mounted @ /mnt/etc/hostname, then assign to HOSTNAME
+elif [ -e /mnt/hostname ]; then
+    HOST_HOSTNAME=$(cat /mnt/hostname)
+    if [ -n "$HOST_HOSTNAME" ]; then
+        HOSTNAME="Hostname \"$HOST_HOSTNAME\""
+        echo "Emitting Metrics With Hostname: \"$HOST_HOSTNAME\""
+    fi
+#The user did not specify and the host's hostname is unavailable
+#Exit with error code 1
+else
+    echo 1>&2 "ERROR: Unable to find the hostname for the docker host. Please \
+specify a hostname with the option -e \"HOSTNAME=<hostname>\" or by \
+mounting the Docker host's hostname \
+-v <path to host's hostname file>:/mnt/hostname:ro"
+    exit 1
 fi
 if [ -z "$COLLECTD_BUFFERSIZE" ]; then
 	COLLECTD_BUFFERSIZE="16384"


### PR DESCRIPTION
… container's hostname rather than the docker host's hostname.  Corrected this issue to use the host's hostname mounted at /mtn/etc/hostname.  If this look up fails and no hostname is specified at runtime, the container's hostname will be the default (Typically the container's container id).

Now we require the user to specify a hostname either via an environment variable or by mounting the host's /etc/hostname to the container.  If neither is available, the container will exit with an error printed to stderr and an exit code of 1.
