### PR TITLE
Using alpine:3.4 as base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM alpine:3.4
 MAINTAINER SignalFx Support <support+collectd@signalfx.com>
 
 # Define collectd and plugin versions
-ENV EXPECTED_PLUGIN_VERSION 0.0.22
-ENV EXPECTED_COLLECTD_VERSION 5.5.1-r0
+ARG EXPECTED_PLUGIN_VERSION=0.0.22
+ARG EXPECTED_COLLECTD_VERSION=5.5.1-r0
 
 # Add default collectd configs
 ADD configs /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,76 +1,66 @@
 # Dockerfile for base collectd install
 
-FROM ubuntu:16.04
+FROM alpine:3.4
 MAINTAINER SignalFx Support <support+collectd@signalfx.com>
 
-# Install common softwares
-ENV DEBIAN_FRONTEND noninteractive
-ENV EXPECTED_PLUGIN_VERSION 0.0.24
-ENV EXPECTED_COLLECTD_VERSION 5.5.1.sfx1
+# Define collectd and plugin versions
+ENV EXPECTED_PLUGIN_VERSION 0.0.22
+ENV EXPECTED_COLLECTD_VERSION 5.5.1-r0
+
+# Add default collectd configs
+ADD configs /tmp/
 
 # Add in startup script
 ADD run.sh /.docker/
-# Setup our collectd
-ADD configs /tmp/
 
-# Install all apt-get utils and required repos
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    # Install add-apt-repository
-    apt-get install -y \
-        software-properties-common && \
-    add-apt-repository -y ppa:signalfx/collectd-release && \
-    add-apt-repository -y ppa:signalfx/collectd-plugin-release && \
-    apt-get update && \
-    # Install
-    apt-get install -y \
-        # Install SignalFx Plugin
-        signalfx-collectd-plugin \
-        # Install collectd
-        collectd \
-        # Install helper packages
-        curl \
-        unzip \
-        # Install pip
-        python-pip && \
-    grep "VERSION = \"$EXPECTED_PLUGIN_VERSION\"" /opt/signalfx-collectd-plugin/signalfx_metadata.py && \
-    collectd -h | grep $EXPECTED_COLLECTD_VERSION && \
+# Install collectd and dependencies
+RUN apk --update add \
+          bash \
+          collectd=${EXPECTED_COLLECTD_VERSION} \
+          collectd-python \
+          collectd-write_http \
+          python \
+    # Installation dependencies that will be removed
+    && apk --update add --virtual install-dependencies \
+          build-base \
+          curl \
+          linux-headers \
+          py-pip \
+          python-dev \
+          tar \
+    # Download the signalfx-collectd-plugin
+    && curl -sL https://github.com/signalfx/signalfx-collectd-plugin/archive/v${EXPECTED_PLUGIN_VERSION}.tar.gz | tar -zxC /tmp \
+    # Install pip requirements for the signalfx-collectd-plugin
+    && pip install -r /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/requirements.txt \
+    # Move the signalfx-collectd-plugin into place
+    && mkdir -p /opt/signalfx-collectd-plugin \
+    && cp /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/src/aggregator.py \
+          /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/src/collectd_dogstatsd.py \
+          /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/src/dogstatsd.py \
+          /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/src/dummy_collectd.py \
+          /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/src/signalfx_metadata.py \
+          /tmp/signalfx-collectd-plugin-${EXPECTED_PLUGIN_VERSION}/types.db.plugin \
+          /opt/signalfx-collectd-plugin/ \
     # Clean up existing configs
-    rm -rf /etc/collectd && \
+    && rm -rf /etc/collectd \
     # Install default configs
-    mv /tmp/collectd /etc/ && \
+    && mv /tmp/collectd /etc/ \
     # Download the SignalFx docker-collectd-plugin
-    curl -L "https://github.com/signalfx/docker-collectd-plugin/archive/master.zip" --output /tmp/docker-collectd-plugin.zip && \
-    # Extract the SignalFx docker-collectd-plugin
-    unzip /tmp/docker-collectd-plugin.zip -d /tmp && \
+    && curl -sL "https://github.com/signalfx/docker-collectd-plugin/archive/master.tar.gz" | tar -zxC /tmp \
     # Move the SignalFx docker-collectd-plugin into place
-    mv /tmp/docker-collectd-plugin-master/ /usr/share/collectd/docker-collectd-plugin && \
+    && mv /tmp/docker-collectd-plugin-master/ /usr/share/collectd/docker-collectd-plugin \
     # Install pip requirements for the docker-collectd-plugin
-    pip install -r /usr/share/collectd/docker-collectd-plugin/requirements.txt && \
+    && pip install -r /usr/share/collectd/docker-collectd-plugin/requirements.txt \
     # Download the configuration file for docker-collectd-plugin
-    curl -L "https://github.com/signalfx/integrations/archive/master.zip" --output /tmp/integrations.zip && \
-    # Extract the configuration file for docker-collectd-plugin
-    unzip /tmp/integrations.zip -d /tmp && \
+    && curl -sL "https://github.com/signalfx/integrations/archive/master.tar.gz" | tar -zxC /tmp \
     # Move the managed config into place
-    cp /tmp/integrations-master/collectd-docker/10-docker.conf /etc/collectd/managed_config/ && \
+    && cp /tmp/integrations-master/collectd-docker/10-docker.conf /etc/collectd/managed_config/ \
     # Set correct permissions on startup script
-    chmod +x /.docker/run.sh && \
+    && chmod +x /.docker/run.sh \
     # Uninstall helper packages
-    apt-get --purge -y remove \
-        software-properties-common \
-        curl \
-        unzip && \
-    # Clean up packages
-    apt-get autoclean && \
-    apt-get clean && \
-    apt-get autoremove -y && \
-    # Remove extraneous files
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /usr/share/man/* && \
-    rm -rf /usr/share/info/* && \
-    rm -rf /var/cache/man/* && \
+    && apk del install-dependencies \
     # Clean up tmp directory
-    rm -rf /tmp/*
+    && rm -rf /tmp/* /var/cache/apk/*
     
 # Change directory and declare startup command
 WORKDIR /.docker/

--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ elif [ -e /mnt/hostname ]; then
 #Exit with error code 1
 else
     echo 1>&2 "ERROR: Unable to find the hostname for the Docker host. Please \
-specify a hostname with the option -e \"HOSTNAME=<hostname>\" or by \
+specify a hostname with the option -e \"COLLECTD_HOSTNAME=<hostname>\" or by \
 mounting the Docker host's hostname \
 -v <path to host's hostname file>:/mnt/hostname:ro"
     exit 1


### PR DESCRIPTION
Using alpine results in a much smaller container (7.5x):

```
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
quay.io/signalfuse/collectd   alpine              1242ce91fd58        5 minutes ago       99.24 MB
quay.io/signalfuse/collectd   latest              b5041fbc3111        2 weeks ago         748.3 MB
```

Uses the alpine-packaged collectd.

Also updated the help text for `-e COLLECTD_HOSTNAME`

Don't merge this until https://github.com/signalfx/signalfx-collectd-plugin/issues/38 is resolved so `EXPECTED_PLUGIN_VERSION` can go back to `0.0.24`
