### PR TITLE
Add dimensions to write_http on ubuntu

### DIFF
--- a/ubuntu/configs/collectd/managed_config/10-write_http-plugin.conf
+++ b/ubuntu/configs/collectd/managed_config/10-write_http-plugin.conf
@@ -3,7 +3,7 @@
 </LoadPlugin>
 <Plugin "write_http">
   <Node "signalfx">
-    URL "%%%INGEST_HOST%%%/v1/collectd%%%AWS_PATH%%%"
+    URL "%%%INGEST_HOST%%%/v1/collectd%%%AWS_PATH%%%%%%DIMENSIONS%%%"
     User "auth"
     Password "%%%API_TOKEN%%%"
     Format "JSON"


### PR DESCRIPTION
Currently the collectd template file differs between ubuntu and alpine versions. This brings the ubuntu template into line with one from the alpine version.