### PR TITLE
Plugins in Ubuntu Image

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,19 @@
+# Collectd with All Plugins
+
+This is a python script to create a Dockerfile that installs all of our
+publically available collectd plugins into the Ubuntu-based collectd image.
+The plugins are specified in the `plugins.yaml` file.  They all get installed
+to `/usr/share/collectd/<plugin_name>`, instead of going all over the
+filesystem.
+
+You can specify extra install steps if necessary by adding a
+`extra_instructions` key to a plugin config object.  The value should be an
+array of instructions which will be run in the Dockerfile in the same `RUN`
+command as the rest of the installation for that plugin.
+
+Additional apt packages can be installed with the key `apt_packages`, and
+additional pip packages with the `pip_packages` key.  These both take arrays of
+package names.
+
+This does not do any configuration, it just installs the plugins without any
+configuration.

--- a/plugins/make-dockerfile.py
+++ b/plugins/make-dockerfile.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import yaml
+import os
+import sys
+import requests
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+TEMPLATE = """
+FROM quay.io/signalfuse/collectd
+
+RUN apt-get update -q &&\\
+    apt-get install -y -q git {extra_apt_packages} &&\\
+    apt-get clean
+
+{plugin_install_steps}
+""".strip()
+
+LABEL = """LABEL com.signalfx.plugin.{plugin_name}.version="{plugin_version}" """.strip()
+
+GIT_CLONE = """
+git clone --branch {tag} --depth 1 --single-branch https://github.com/{repo_name}.git /usr/share/collectd/{plugin_name} &&\\
+    rm -rf /usr/share/collectd/{plugin_name}/.git
+""".strip()
+
+PIP_INSTALL = """pip install {}"""
+
+RUN = """RUN {}"""
+
+def to_stderr(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def read_plugin_list(config_path):
+    with open(config_path, 'r') as f:
+        return yaml.load(f)
+
+def get_latest_release_from_github(repo):
+    resp = requests.get("https://api.github.com/repos/{}/releases/latest".format(repo))
+    if resp.status_code == 404:
+        return None
+
+    return resp.json()
+
+def get_release_from_github(repo, tag):
+    resp = requests.get("https://api.github.com/repos/{}/releases/tags/{}".format(repo, tag))
+    resp.raise_for_status()
+
+    return resp.json()
+
+def get_commit_hash_for_branch(branch, repo):
+    resp = requests.get("https://api.github.com/repos/{}/branches/master".format(repo))
+
+    return resp.json()['commit']['sha']
+
+def docker_commands_for_plugin(plugin):
+    if plugin['version'] == "latest":
+        release = get_latest_release_from_github(plugin['repo'])
+        if release:
+            tag_name = version = release['tag_name']
+        if not release:
+            # This is subject to a race condition if the image is built after
+            # master changes.  The commit hash would no longer be accurate.  It
+            # is much better to do releases and have named tags.
+            tag_name = 'master'
+            version = get_commit_hash_for_branch('master', plugin['repo'])
+    else:
+        release = get_release_from_github(plugin['repo'], plugin['version'])
+
+    lines = []
+    lines.append(GIT_CLONE.format(tag=tag_name,
+                                  repo_name=plugin['repo'],
+                                  plugin_name=plugin['name']))
+
+    if 'pip_packages' in plugin:
+        lines.append(PIP_INSTALL.format(' '.join(plugin['pip_packages'])))
+
+    if 'extra_instructions' in plugin:
+        lines.extend(plugin['extra_instructions'])
+
+    run = RUN.format(" &&\\\n    ".join(lines))
+
+    label = LABEL.format(plugin_name=plugin['name'],
+                         plugin_version=version.lstrip('v'))
+
+    return run + "\n" + label
+
+def make_dockerfile(plugin_config_path):
+    extra_apt_packages = []
+    plugin_install_steps = []
+
+    for plugin in read_plugin_list(plugin_config_path):
+        extra_apt_packages.extend(plugin.get('apt_packages', []))
+        plugin_install_steps.append(docker_commands_for_plugin(plugin))
+
+    return TEMPLATE.format(extra_apt_packages=" ".join(extra_apt_packages),
+                           plugin_install_steps="\n\n".join(plugin_install_steps))
+
+
+if __name__ == "__main__":
+    print(make_dockerfile(os.path.join(SCRIPT_DIR, "plugins.yaml")))

--- a/plugins/plugins.yaml
+++ b/plugins/plugins.yaml
@@ -1,0 +1,46 @@
+---
+- name: elasticsearch
+  version: latest
+  repo: signalfx/collectd-elasticsearch
+
+- name: mongodb
+  version: latest
+  repo: signalfx/collectd-mongodb
+  pip_packages:
+    - pymongo==3.1.1
+
+- name: zookeeper
+  version: latest
+  repo: signalfx/collectd-zookeeper
+
+- name: haproxy
+  version: latest
+  repo: signalfx/collectd-haproxy
+
+- name: couchbase
+  version: latest
+  repo: signalfx/collectd-couchbase
+
+- name: redis
+  version: latest
+  repo: signalfx/redis-collectd-plugin
+
+- name: rabbitmq
+  version: latest
+  repo: signalfx/collectd-rabbitmq
+
+- name: marathon
+  version: latest
+  repo: signalfx/collectd-marathon
+
+- name: vmstat
+  version: latest
+  repo: signalfx/vmstat-collectd
+
+#- name: timestats
+  #version: latest
+  #repo: signalfx/collectd-timestats
+
+#- name: cassandra
+  #version: latest
+  #repo: signalfx/collectd-cassandra

--- a/plugins/requirements.txt
+++ b/plugins/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML>=3
+requests>=2
+


### PR DESCRIPTION
- This adds a script that makes a dockerfile that extends the Ubuntu Collectd
  image to include all of the collectd python plugins that we have forked in
  our github repo.

This makes more sense to put in this repo rather than the signalfx/integration-imaging-toolkit repo because it is based on the Ubuntu image created here, and this is much simpler than what that repo is attempting to do.