### PR TITLE
Don't uninstall curl, we need it to make AWSUniqueID

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -51,7 +51,6 @@ RUN apt-get update \
     # Uninstall helper packages
     && apt-get --purge -y remove \
         software-properties-common \
-        curl \
         unzip \
     # Clean up packages
     && apt-get autoclean \


### PR DESCRIPTION
Fixes an issue mentioned at https://github.com/signalfx/docker-collectd/pull/57#issuecomment-364273794